### PR TITLE
fix: support jasmine-core 6 in test tooling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,12 +45,12 @@
         "eslint-plugin-prettier": "^5.5.5",
         "eslint-plugin-promise": "^7.2.1",
         "globals": "^17.4.0",
-        "jasmine-core": "~5.13.0",
+        "jasmine-core": "~6.0.1",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.2.0",
         "karma-coverage": "~2.2.0",
         "karma-jasmine": "~5.1.0",
-        "karma-jasmine-html-reporter": "~2.2.0",
+        "karma-jasmine-html-reporter": "^2.2.0",
         "typescript": "~5.9.3"
       }
     },
@@ -12423,9 +12423,9 @@
       }
     },
     "node_modules/jasmine-core": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.13.0.tgz",
-      "integrity": "sha512-vsYjfh7lyqvZX5QgqKc4YH8phs7g96Z8bsdIFNEU3VqXhlHaq+vov/Fgn/sr6MiUczdZkyXRC3TX369Ll4Nzbw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.0.1.tgz",
+      "integrity": "sha512-gUtzV5ASR0MLBwDNqri4kBsgKNCcRQd9qOlNw/w/deavD0cl3JmWXXfH8JhKM4LTg6LPTt2IOQ4px3YYfgh2Xg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -50,12 +50,12 @@
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-promise": "^7.2.1",
     "globals": "^17.4.0",
-    "jasmine-core": "~5.13.0",
+    "jasmine-core": "~6.0.1",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
-    "karma-jasmine-html-reporter": "~2.2.0",
+    "karma-jasmine-html-reporter": "^2.2.0",
     "typescript": "~5.9.3"
   }
 }


### PR DESCRIPTION
## Summary
- update karma-jasmine-html-reporter to a version that supports jasmine-core 6
- refresh package-lock.json accordingly

## Why
The dependency PR #51 bumps jasmine-core to 6.0.1, but the existing test reporter range only supports jasmine-core 4 or 5.

## Related
- helps unblock #51
